### PR TITLE
use publicly accessible docker images for building

### DIFF
--- a/.build/Jenkinsfile
+++ b/.build/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
       inheritFrom 'base'
       containerTemplate {
         name 'composer'
-        image 'us.gcr.io/mautic-ma/composer:master'
+        image 'php:7.4'
         ttyEnabled true
         command 'cat'
       }
@@ -20,9 +20,12 @@ pipeline {
         container('composer') {
           ansiColor('xterm') {
             sh """
-              composer install --ansi
+              .build/install-composer.sh
+              apt update && apt install git jq ssh-client unzip zip -y
+              mkdir -p /root/.ssh/ && ssh-keyscan github.com >> /root/.ssh/known_hosts
+
+              ./composer.phar install --ansi
               mkdir PACKS && chmod 777 PACKS
-              whoami
             """
           }
           dir('PACKS') {

--- a/.build/Jenkinsfile
+++ b/.build/Jenkinsfile
@@ -1,3 +1,5 @@
+@Library('jenkins-scripts') _
+
 pipeline {
   triggers {
     cron('H H * * *')
@@ -65,8 +67,13 @@ pipeline {
   post {
     failure {
       script {
-        echo slackSend (color: '#FF0000', message: "Language packer job failed.")
+        postFailureScript()
       }
     }
-  }
+    fixed {
+      script {
+        postFixedScript()
+      }
+    }
+  }    
 }

--- a/.build/install-composer.sh
+++ b/.build/install-composer.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]
+then
+    >&2 echo 'ERROR: Invalid installer checksum'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+RESULT=$?
+rm composer-setup.php
+exit $RESULT

--- a/src/Application.php
+++ b/src/Application.php
@@ -229,7 +229,20 @@ class Application extends AbstractCliApplication
                 // We only want resources which match our minimum completion level unless told to bypass the completion check
                 if ($this->input->getBool('bypasscompletion', false) || $completed >= $completion)
                 {
-                    $translation = $transifex->get('translations')->getTranslation('mautic', $resource->slug, $this->languages[$language]);
+                    $maxAttempts=5;
+                    for($attempt=1;$attempt<=$maxAttempts; $attempt++) {
+                        try {
+                            $translation = $transifex->get('translations')->getTranslation('mautic', $resource->slug, $this->languages[$language]);
+                            break;
+                        }
+                        catch (\Exception $e) {
+                            if($attempt == $maxAttempts) {
+                                throw $e;
+                            }
+                            $this->out("Encountered error during download. Retrying. Attempt $attempt. Error:".$e->getMessage());
+                            sleep(pow(2,$attempt));
+                        }
+                    }
 
                     $path = $translationDir . '/' . $language . '/' . $bundle . '/' . $file . '.ini';
                     $bundlePath = $translationDir . '/' . $language . '/' . $bundle;

--- a/src/Application.php
+++ b/src/Application.php
@@ -342,7 +342,7 @@ class Application extends AbstractCliApplication
                         )
                     );
                 }
-                if (!file_put_contents($translationDir . '/' . $languageDir . '/config.json', json_encode($packageMetadata)))
+                if (!file_put_contents($translationDir . '/' . $languageDir . '/config.json', json_encode($packageMetadata)."\n"))
                 {
                     throw new \RuntimeException(
                         sprintf(


### PR DESCRIPTION
Language build stopped working due to a problem with the docker image it was using. I took the opportunity to replace the acquia image with publicly accessible one.

During tests I ran into a high failure rate of the transifex api. It was almost imposible to complete the build because I was geting random api errors. To mitigate this problem I implemented a simply retry logic in the api downloader.