### PR TITLE
Rename GITHUB_TOKEN to NEW_GITHUB_TOKEN

### DIFF
--- a/.github/workflows/package-build.yaml
+++ b/.github/workflows/package-build.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           repository: 'mautic/language-packs'
           ref: 'master'
-          token: '${{ secrets.GITHUB_TOKEN }}'
+          token: '${{ secrets.NEW_GITHUB_TOKEN }}'
           path: 'PACKS'
 
       - name: Push packages to language-packs

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ In `https://github.com/<username>/language-packer/settings/secrets/actions/new`,
 1. `TRANSIFEX_API_TOKEN` // Generate a Transifex API token from https://app.transifex.com/user/settings/api/
 2. `TRANSIFEX_ORGANISATION`
 3. `TRANSIFEX_PROJECT`
-4. `GITHUB_TOKEN` // details below
+4. `NEW_GITHUB_TOKEN` // details below
 
 ##### Github Token
 
 1. Create a Github token for pushing packages to language-packs repo
-2. Copy this token and create a new secret with `GITHUB_TOKEN` name in `https://github.com/<username>/language-packer/settings/secrets/actions/new`
+2. Copy this token and create a new secret with `NEW_GITHUB_TOKEN` name in `https://github.com/<username>/language-packer/settings/secrets/actions/new`


### PR DESCRIPTION
Rename GITHUB_TOKEN because of error: Failed to add secret. Secret names must not start with GITHUB_.
The new secret name is NEW_GITHUB_TOKEN.