### PR TITLE
Fix folder structure for language-packs

### DIFF
--- a/src/Service/BuildPackageService.php
+++ b/src/Service/BuildPackageService.php
@@ -145,21 +145,21 @@ class BuildPackageService
         $zipArchive = new \ZipArchive();
 
         if ($zipArchive->open($packagesTimestampDir.'/'.$languageCode.'.zip', \ZipArchive::CREATE)) {
+            $zipArchive->addEmptyDir($languageCode);
             $languageDirFinder = (new Finder())->in($languageDir)->ignoreDotFiles(true)->ignoreVCS(true);
 
             foreach ($languageDirFinder as $file) {
-                if ($file->isFile()) {
-                    $filePath     = $file->getRealPath();
-                    $relativePath = $file->getRelativePathname();
+                $relativePath = $file->getRelativePath();
 
-                    // Add the directory if it hasn't already been added
-                    $directory = dirname($relativePath);
-
-                    if ('.' !== $directory && !$zipArchive->getFromName($directory.'/')) {
-                        $zipArchive->addEmptyDir($directory);
-                    }
-
-                    $zipArchive->addFile($filePath, $relativePath);
+                if ($file->isDir()) {
+                    // Add empty directory to the zip archive
+                    $zipArchive->addEmptyDir($languageCode.'/'.$relativePath);
+                } elseif ($file->isFile()) {
+                    // Add file to the zip archive
+                    $zipArchive->addFile(
+                        $file->getPathname(),
+                        $languageCode.'/'.$relativePath.'/'.$file->getFilename()
+                    );
                 }
             }
 


### PR DESCRIPTION
The Github actions started working for mautic/language-packer recently which updated the mautic/language-packs repo.
I compared the old and new zips after unzipping them, and they appear to have same folder structure.
But there was a minute difference, the older zip files had the language-code folder zipped in them as well.
So, when you download the new zip from the update language-packs repo, it didn't had this language-code folder and thus it displayed this error like `Failed to copy "var/tmp/ar/config.json" because file does not exist.`

This PR fixes this issue mentioned [here](https://github.com/mautic/language-packer/pull/2#issuecomment-1569793787).

Please see MauticLanguagePackerCommandTest::testPackageZipFolderStructure to verify without waiting for language-packs to build.