### PR TITLE
Remove invalid ini files from zip

### DIFF
--- a/src/Service/Transifex/TranslationsService.php
+++ b/src/Service/Transifex/TranslationsService.php
@@ -52,6 +52,7 @@ class TranslationsService
 
                 sleep(2 ** $attempt);
             } catch (InvalidFileException|RegexException $e) {
+                $this->filesystem->remove($filePath);
                 $this->outputErrors($logger, $filePath, $e->getMessage());
                 break;
             }


### PR DESCRIPTION
The language `pt_BR` and `tr` have invalid `LeadBundle/messages.ini`.
The `mautic.lead.event.donotcontact_channel` key in this INI file is missing end quotes (").

pt_BR:
![Screenshot 2023-07-06 at 15 25 24](https://github.com/mautic/language-packer/assets/54406786/7ca02777-f156-4659-bbeb-b91f033eff03)

tr:
![Screenshot 2023-07-06 at 15 25 16](https://github.com/mautic/language-packer/assets/54406786/d56d6a22-6828-424e-acf1-b55a01e6cb6d)

The language packer throws error but still includes the ini file in the final zip package.
![Screenshot 2023-07-06 at 15 28 04](https://github.com/mautic/language-packer/assets/54406786/ad26dd66-6f44-4c7e-8d99-1af502b64535)

This PR removes such invalid INIs before the zip is generated.