### PR TITLE
Modify workflow to maintain repository activity

### DIFF
--- a/.github/workflows/package-build.yaml
+++ b/.github/workflows/package-build.yaml
@@ -17,15 +17,20 @@ jobs:
     container:
       image: php:8.1
     steps:
+      - name: Install git
+        run: apt update && apt install -y git
+
       - name: Install PHP zip extension
         run: apt-get update && apt-get install -y libzip-dev && docker-php-ext-install zip
+
+      - name: Set GitHub workspace as safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Checkout code
         uses: actions/checkout@v3
 
       - name: Install composer
-        run: |
-          curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+        run: curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
       - name: Install dependencies
         run: |
@@ -33,9 +38,17 @@ jobs:
           mkdir -p ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
           composer install
 
-      - name: Build packages
+      - name: Build language packages
+        run: bin/console mautic:language:packer --skip-languages=en
+
+      - name: Update build timestamp in last_build file
         run: |
-          bin/console mautic:language:packer --skip-languages=en
+          echo "Last language packages build: $(date)" > last_build
+          git config user.name "Automated build"
+          git config user.email "action@github.com"
+          git add -f last_build
+          git commit -m "update build timestamp in last_build file"
+          git push origin HEAD:master
 
       - name: Checkout language-packs to PACKS dir
         uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@
 /bin/*
 !/bin/console
 
+last_build
+
 ###> symfony/framework-bundle ###
 /.env.local
 /.env.local.php


### PR DESCRIPTION
There is an issue where the language packer workflow gets automatically disabled every 60 days due to repository inactivity.

This PR addresses the issue by modifying the workflow to create or update a last_build file in this repository. By maintaining regular repository activity, this change ensures that the workflow will not be disabled in the future.

Changes:
* Modified the workflow to create/update a last_build file with the timestamp of the last language packages build.
* Added last_build to .gitignore file.