### PR TITLE
Use defined NEW_GITHUB_TOKEN for pushing last_build change

### DIFF
--- a/.github/workflows/package-build.yaml
+++ b/.github/workflows/package-build.yaml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          token: '${{ secrets.NEW_GITHUB_TOKEN }}'
 
       - name: Install composer
         run: curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer


### PR DESCRIPTION
This PR addresses the issue where the build fails due to branch protection rules on the master branch. Since the language-packs repository has branch protection, we can apply the same approach to the language-packer repository.

Changes:
* Modified the workflow to push the last_build change using a defined GitHub token NEW_GITHUB_TOKEN.

Note: Please ensure that the GitHub token (NEW_GITHUB_TOKEN secret) has access to this repository. If not, generate a new token with access to both repositories (language-packer and language-packs) and update the current one.