### PR TITLE
Increase CI memory limit for language packer

### DIFF
--- a/.github/workflows/package-build.yaml
+++ b/.github/workflows/package-build.yaml
@@ -42,7 +42,7 @@ jobs:
           composer install
 
       - name: Build language packages
-        run: bin/console mautic:language:packer --skip-languages=en
+        run: php -d memory_limit=512M bin/console mautic:language:packer --skip-languages=en
 
       - name: Update build timestamp in last_build file
         run: |


### PR DESCRIPTION
The [build](https://github.com/mautic/language-packer/actions/runs/22833122510/job/66224572038) started failing with
```
[info] Translation for /__w/language-packer/language-packer/translations/ja/PluginBundle/validators.ini was downloaded successfully!
[info] Processing the PluginBundle "validators" resource in "nl" language.

Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 20480 bytes) in /__w/language-packer/language-packer/vendor/***/transifex/src/ApiConnector.php on line 152
[critical] Fatal Error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 20480 bytes)


Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 32768 bytes) in /__w/language-packer/language-packer/vendor/symfony/string/Resources/data/wcswidth_table_zero.php on line 1
Error: Process completed with exit code 255.
```
This PR increases memory limit from the default 134MB to 512MB.